### PR TITLE
Fix: css typo

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -30,19 +30,19 @@
             $('#view-div').css('display','none');
             
             $('#header-div').hover(function(){
-            $('#header-div').attr('class','tony-header-scoll');
+            $('#header-div').attr('class','tony-header-scroll');
             },function(){
             $('#header-div').attr('class','tony-header-fixed');
             })
             
         }else{
-            $('#header-div').attr('class','tony-header-scoll');
+            $('#header-div').attr('class','tony-header-scroll');
             $('#view-div').css('display','block');
             
             $('#header-div').hover(function(){
-            $('#header-div').attr('class','tony-header-scoll');
+            $('#header-div').attr('class','tony-header-scroll');
             },function(){
-            $('#header-div').attr('class','tony-header-scoll');
+            $('#header-div').attr('class','tony-header-scroll');
             })
         }
       });

--- a/src/css/style_dark.scss
+++ b/src/css/style_dark.scss
@@ -16,7 +16,7 @@ Mode: Dark
     }
 }
 
-.tony-header-scoll {
+.tony-header-scroll {
     box-shadow: none !important;
     background: linear-gradient(180deg, #1c1f2c, transparent) !important;
 }

--- a/src/css/style_light.scss
+++ b/src/css/style_light.scss
@@ -1964,7 +1964,7 @@ table {
     transition: ease-in-out .2s;
 }
 
-.tony-header-scoll {
+.tony-header-scroll {
     @extend .tony-header-fixed;
     box-shadow: rgba(0, 0, 0, 0.04) 0px 4px 8px;
     background: #fff;


### PR DESCRIPTION
修复 scss 样式文件及 js 文件中`scoll`->`scroll`的typo